### PR TITLE
fix: entityLookup trailing url

### DIFF
--- a/src/services/addressResolver/index.test.ts
+++ b/src/services/addressResolver/index.test.ts
@@ -1,6 +1,6 @@
 import axios from "axios";
 import { ThirdPartyAPIEntryProps } from "../../types";
-import { getFeatures, getIdentity, getPath } from "./index";
+import { getFeatures, getIdentity, getPath, entityLookup } from "./index";
 
 jest.mock("axios");
 jest.mock("./axiosClient");
@@ -173,6 +173,61 @@ describe("addressResolver", () => {
       const e = new Error("Generic error message");
       mockedAxios.get.mockRejectedValueOnce(e);
       await expect(getFeatures("https://some.url", "key", "value")).rejects.toThrow(/Generic error message/);
+    });
+  });
+
+  describe("entityLookup", () => {
+    const data = {
+      identities: [
+        {
+          identifier: "0x3aaff3bf29cd85a7ba3dec33f5d0269e72097d26",
+          name: "TradeSafe.Club",
+          source: "",
+          remarks: "Added by Marcus Ong",
+        },
+      ],
+      count: 1,
+      total: 1,
+    };
+
+    it("should call when endpoint is without trailing slash", async () => {
+      mockedAxios.get.mockResolvedValueOnce({
+        data: data,
+      });
+      const response = await entityLookup({
+        limit: "20",
+        offset: "1",
+        query: "Marcus",
+        endpoint: "https://some.url",
+        apiHeader: "x-api-key",
+        apiKey: "DEMO",
+        path: "/search",
+      });
+
+      expect(mockedAxios.get).toHaveBeenCalledWith("https://some.url/search?limit=20&offset=1&q=Marcus", {
+        headers: { "x-api-key": "DEMO" },
+      });
+      expect(response).toEqual(data);
+    });
+
+    it("should call when endpoint is with trailing slash", async () => {
+      mockedAxios.get.mockResolvedValueOnce({
+        data: data,
+      });
+      const response = await entityLookup({
+        limit: "20",
+        offset: "1",
+        query: "Marcus",
+        endpoint: "https://some.url/",
+        apiHeader: "x-api-key",
+        apiKey: "DEMO",
+        path: "/search",
+      });
+
+      expect(mockedAxios.get).toHaveBeenCalledWith("https://some.url/search?limit=20&offset=1&q=Marcus", {
+        headers: { "x-api-key": "DEMO" },
+      });
+      expect(response).toEqual(data);
     });
   });
 });

--- a/src/services/addressResolver/index.ts
+++ b/src/services/addressResolver/index.ts
@@ -17,7 +17,7 @@ interface EntityLookupProps {
   endpoint: string;
   apiHeader?: string;
   apiKey?: string;
-  path?: string;
+  path: string;
 }
 
 interface ResolveAddressIdentityByEndpointProps {
@@ -56,10 +56,6 @@ export const entityLookup = async ({
   apiKey,
   path,
 }: EntityLookupProps): Promise<EntityLookupResponseProps> => {
-  if (!path) {
-    throw "This endpoint does not have the entityLookup feature.";
-  }
-
   const url = queryString.stringifyUrl({
     url: getPath(path, endpoint),
     query: {

--- a/src/services/addressResolver/index.ts
+++ b/src/services/addressResolver/index.ts
@@ -17,6 +17,7 @@ interface EntityLookupProps {
   endpoint: string;
   apiHeader?: string;
   apiKey?: string;
+  path?: string;
 }
 
 interface ResolveAddressIdentityByEndpointProps {
@@ -53,9 +54,14 @@ export const entityLookup = async ({
   endpoint,
   apiHeader,
   apiKey,
+  path,
 }: EntityLookupProps): Promise<EntityLookupResponseProps> => {
+  if (!path) {
+    throw "This endpoint does not have the entityLookup feature.";
+  }
+
   const url = queryString.stringifyUrl({
-    url: `${endpoint}search`,
+    url: getPath(path, endpoint),
     query: {
       q: query,
       limit,


### PR DESCRIPTION
- should call entityLookup with or without trailing slash
- related pr https://github.com/TradeTrust/tradetrust-website/pull/257
- story: https://www.pivotaltracker.com/story/show/175279557